### PR TITLE
Fix undefined property: Psalm\Codebase

### DIFF
--- a/src/OnlineChecker.php
+++ b/src/OnlineChecker.php
@@ -106,15 +106,15 @@ class OnlineChecker
             $track_taints = preg_match('/^\<\?php\s*\/\/\s*(--taint-analysis|checkTaintedInput|trackTaints)\b/', $file_contents) > 0;
 
 		    if ($track_taints) {
-		    	$codebase->control_flow_graph = new \Psalm\Internal\Codebase\ControlFlowGraph();
+		    	$codebase->taint_flow_graph = new \Psalm\Internal\Codebase\ControlFlowGraph();
 		    }
 
 		    $file_checker->analyze($context);
 
 		    $i = 0;
 
-		    if ($codebase->control_flow_graph) {
-            	$codebase->control_flow_graph->connectSinksAndSources();
+		    if ($codebase->taint_flow_graph) {
+            	$codebase->taint_flow_graph->connectSinksAndSources();
         	}
 
 		    if (($settings['unused_methods'] ?? false) || strpos($file_contents, '<?php // findUnusedCode') === 0) {


### PR DESCRIPTION
Online checker is not working right now. The problem is warning in the response breaking JSON.

<img width="1431" alt="image" src="https://user-images.githubusercontent.com/1233843/94262556-55c02d80-ff3c-11ea-9e05-5a8a5ed43754.png">

I think warnings should be disabled in production. And it would be better to analyze the project itself with psalm :)